### PR TITLE
main: set default OpenGL version to 4.1 on macOS

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,6 @@
 #include <QFontDatabase>
 #include <QMessageBox>
 #include <QSettings>
-#include <QSurfaceFormat>
 
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
     #include <QStandardPaths>
@@ -32,6 +31,7 @@
 
 #if __APPLE__
     #include <locale.h>
+    #include <QSurfaceFormat>
 #endif
 
 #include "audio/audioplayer.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,7 @@
 #include <QFontDatabase>
 #include <QMessageBox>
 #include <QSettings>
+#include <QSurfaceFormat>
 
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
     #include <QStandardPaths>
@@ -132,6 +133,14 @@ int main(int argc, char *argv[])
 
     /* Construct the application */
     QApplication memento(argc, argv);
+
+#if __APPLE__
+    QSurfaceFormat qSurfaceFormat;
+    qSurfaceFormat.setMajorVersion(4);
+    qSurfaceFormat.setMinorVersion(1);
+    qSurfaceFormat.setProfile(QSurfaceFormat::CoreProfile);
+    QSurfaceFormat::setDefaultFormat(qSurfaceFormat);
+#endif
 
 #if !__APPLE__
     /* Set the window icon */


### PR DESCRIPTION
[By default](https://doc.qt.io/qt-5/qsurfaceformat.html#QSurfaceFormat), Qt seems to render with OpenGL 2.0. On macOS, this causes mpv rendering issues:

```
[libmpv_render] Disabling scaler #0 ewa_lanczossharp (GLSL version too old).
[libmpv_render] Disabling scaler #1 mitchell (GLSL version too old).
[libmpv_render] Disabling scaler #2 spline36 (GLSL version too old).
[libmpv_render] Disabling linear/sigmoid scaling (GLSL version too old).
[libmpv_render] Disabling debanding (GLSL version too old).
[libmpv_render] correct-downscaling requires non-bilinear scaler.
[libmpv_render/videotoolbox] need >= OpenGL 3.0 for core rectangle texture support
```

OpenGL has been deprecated by Apple since macOS 10.14. Most current devices [support OpenGL 4.1](https://support.apple.com/en-us/HT202823). This PR sets the [`QSurfaceFormat` global default surface format](https://doc.qt.io/qt-5/qsurfaceformat.html#setDefaultFormat) to 4.1 on macOS to address this.

This patch is only applying to macOS as I am currently unable to test other platforms and because users on other platforms have not mentioned any issues with OpenGL versions.

(This is my best effort fix. Please feel free to change it as I don't really understand enough Qt.)