### PR TITLE
Option automatically to pause on subtitle end

### DIFF
--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -136,6 +136,20 @@
     <string>Add Subtitle File</string>
    </property>
   </action>
+  <action name="actionSubtitlePause">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Auto Pause</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+P</string>
+   </property>
+  </action>
   <action name="actionUpdate">
    <property name="text">
     <string>Check for Updates</string>

--- a/src/gui/widgets/overlay/playermenu.h
+++ b/src/gui/widgets/overlay/playermenu.h
@@ -152,6 +152,11 @@ private Q_SLOTS:
     void openConfigFolder() const;
 
     /**
+     * Updates the menu checkbox for the option to pause on subtitle end.
+     */
+    void updateSubtitlePauseAction();
+
+    /**
      * Updates the values under Settings -> Anki Profile with up to date
      * information.
      */
@@ -181,6 +186,11 @@ private:
      * @return A QAction corresponding to the track. Belongs to the caller.
      */
     QAction *createTrackAction(const Track *track) const;
+
+    /**
+     * Toggles pausing on subtitle end in response to the menu option.
+     */
+    void applySubtitlePauseSetting();
 
     Ui::PlayerMenu *m_ui;
 

--- a/src/gui/widgets/overlay/playermenu.ui
+++ b/src/gui/widgets/overlay/playermenu.ui
@@ -100,6 +100,7 @@
        <addaction name="actionSubtitleTwoNone"/>
       </widget>
       <addaction name="actionAddSubtitle"/>
+      <addaction name="actionSubtitlePause"/>
       <addaction name="menuSubtitleTwo"/>
       <addaction name="separator"/>
       <addaction name="actionSubtitleNone"/>
@@ -216,6 +217,20 @@
   <action name="actionAddSubtitle">
    <property name="text">
     <string>Add Subtitle File</string>
+   </property>
+  </action>
+  <action name="actionSubtitlePause">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Auto Pause</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+P</string>
    </property>
   </action>
   <action name="actionUpdate">

--- a/src/gui/widgets/overlay/subtitlewidget.cpp
+++ b/src/gui/widgets/overlay/subtitlewidget.cpp
@@ -40,6 +40,10 @@
 /* Prevents valid subtitles from being hidden due to double precision errors. */
 #define DOUBLE_DELTA 0.05
 
+/* If pausing on subtitle end is enabled, prevents pausing on the next
+ * subtitle. */
+#define PAUSE_DELTA 0.028
+
 /* Begin Constructor/Destructor */
 
 SubtitleWidget::SubtitleWidget(QWidget *parent)
@@ -478,9 +482,12 @@ void SubtitleWidget::adjustVisibility()
 
 void SubtitleWidget::positionChanged(const double value)
 {
-    if (m_settings.pauseOnSubtitleEnd
-        && !m_pausedForCurrentSubtitle
-        && (m_subtitle.endTime - value <= 0))
+    const double timeToSubtitleEnd = m_subtitle.endTime - value;
+    if (m_settings.pauseOnSubtitleEnd &&
+        !m_pausedForCurrentSubtitle &&
+        timeToSubtitleEnd >= DOUBLE_DELTA * -4 &&
+        timeToSubtitleEnd <= PAUSE_DELTA &&
+        value > DOUBLE_DELTA * 4)
     {
          GlobalMediator::getGlobalMediator()->getPlayerAdapter()->pause();
          m_pausedForCurrentSubtitle = true;

--- a/src/gui/widgets/overlay/subtitlewidget.h
+++ b/src/gui/widgets/overlay/subtitlewidget.h
@@ -157,6 +157,10 @@ private:
     /* Saved pause state of the player. */
     bool m_paused;
 
+    /* True if playback has already been paused for the current subtitle, false
+     * otherwise. */
+    bool m_pausedForCurrentSubtitle = false;
+
     /* Contains information about the current subtitle. */
     struct Subtitle
     {
@@ -212,6 +216,10 @@ private:
 
         /* true if subtitles should be shown when needed, false otherwise. */
         bool showSubtitles;
+
+	/* True if playback should be paused for the current subtitle, false
+	 * otherwise. */
+	bool pauseOnSubtitleEnd;
     } m_settings;
 };
 

--- a/src/gui/widgets/settings/behaviorsettings.cpp
+++ b/src/gui/widgets/settings/behaviorsettings.cpp
@@ -88,6 +88,12 @@ void BehaviorSettings::restoreSaved()
             SETTINGS_BEHAVIOR_AUTOFIT_PERCENT_DEFAULT
         ).toInt()
     );
+    m_ui->checkSubtitlePause->setChecked(
+        settings.value(
+            SETTINGS_BEHAVIOR_SUBTITLE_PAUSE,
+            SETTINGS_BEHAVIOR_SUBTITLE_PAUSE_DEFAULT
+        ).toBool()
+    );
     settings.endGroup();
 }
 
@@ -95,6 +101,9 @@ void BehaviorSettings::restoreDefaults()
 {
     m_ui->checkAutofit->setChecked(SETTINGS_BEHAVIOR_AUTOFIT_DEFAULT);
     m_ui->spinAutofit->setValue(SETTINGS_BEHAVIOR_AUTOFIT_PERCENT_DEFAULT);
+    m_ui->checkSubtitlePause->setChecked(
+        SETTINGS_BEHAVIOR_SUBTITLE_PAUSE_DEFAULT
+    );
 }
 
 void BehaviorSettings::applySettings()
@@ -107,7 +116,12 @@ void BehaviorSettings::applySettings()
     settings.setValue(
         SETTINGS_BEHAVIOR_AUTOFIT_PERCENT, m_ui->spinAutofit->value()
     );
+    settings.setValue(
+        SETTINGS_BEHAVIOR_SUBTITLE_PAUSE, m_ui->checkSubtitlePause->isChecked()
+    );
     settings.endGroup();
+
+    Q_EMIT GlobalMediator::getGlobalMediator()->behaviorSettingsChanged();
 }
 
 /* Begin Button Box Handlers */

--- a/src/gui/widgets/settings/behaviorsettings.ui
+++ b/src/gui/widgets/settings/behaviorsettings.ui
@@ -84,6 +84,13 @@ A value of 0% will fit to media to the window size instead.</string>
         </layout>
        </item>
        <item>
+        <widget class="QCheckBox" name="checkSubtitlePause">
+         <property name="text">
+          <string>Automatically pause the player at the end of a subtitle</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/gui/widgets/settings/behaviorsettings.ui
+++ b/src/gui/widgets/settings/behaviorsettings.ui
@@ -86,7 +86,7 @@ A value of 0% will fit to media to the window size instead.</string>
        <item>
         <widget class="QCheckBox" name="checkSubtitlePause">
          <property name="text">
-          <string>Automatically pause the player at the end of a subtitle</string>
+          <string>Automatically pause at the end of subtitles</string>
          </property>
         </widget>
        </item>

--- a/src/util/constants.h
+++ b/src/util/constants.h
@@ -54,6 +54,9 @@
 #define SETTINGS_BEHAVIOR_AUTOFIT_PERCENT           "autofit-percent"
 #define SETTINGS_BEHAVIOR_AUTOFIT_PERCENT_DEFAULT   100
 
+#define SETTINGS_BEHAVIOR_SUBTITLE_PAUSE            "subtitle-pause"
+#define SETTINGS_BEHAVIOR_SUBTITLE_PAUSE_DEFAULT    false
+
 /* Dictionary Settings */
 #define SETTINGS_DICTIONARIES           "dictionaries"
 

--- a/src/util/globalmediator.h
+++ b/src/util/globalmediator.h
@@ -346,6 +346,11 @@ Q_SIGNALS:
     void ankiSettingsChanged() const;
 
     /**
+     * Emitted when behavior settings are changed.
+     */
+    void behaviorSettingsChanged() const;
+
+    /**
      * Emitted when search settings are changed.
      */
     void searchSettingsChanged() const;


### PR DESCRIPTION
Before anything else, thank you for producing this amazing software.

In trying it, however, I felt it was lacking a few [Language Reactor playback features](https://www.languagereactor.com/help/basic), so I decided to add them for my own comfort, starting with autopause on subtitle end. I have added an "Automatically pause the player at the end of a subtitle" checkbox, unchecked by default, in the "Behavior" settings.

It seems to be a popular enough feature among language learners that I thought it worth cleaning up and opening a PR for.

(As an habitual MPC-HC user, I started writing this before realizing just how extensible through scripts mpv actually is, and subsequently found that there are two scripts, [sub-pause](https://github.com/Ben-Kerman/mpv-sub-scripts) and [sub-replay](https://github.com/kelciour/mpv-scripts/blob/master/sub-replay.lua), which also provide Language Reactor playback controls; however, the former pauses too soon with the .ass files I've tried and the latter only works with .srt files.)