### PR TITLE
mpvadapter: quote command line args

### DIFF
--- a/src/gui/mpvadapter.cpp
+++ b/src/gui/mpvadapter.cpp
@@ -204,6 +204,16 @@ MpvAdapter::MpvAdapter(MpvWidget *mpv, QObject *parent)
     );
 }
 
+QString MpvAdapter::quoteArg(QString arg) const
+{
+    int eqidx = arg.indexOf("=");
+    if (eqidx == -1)
+    {
+        return arg;
+    }
+    return arg.insert(eqidx + 1, "\"").append("\"");
+}
+
 bool MpvAdapter::commandLineArgsValid(const QStringList &args) const
 {
     int count = 0;
@@ -255,7 +265,7 @@ int MpvAdapter::buildArgsTree(const QStringList &args,
         }
         else if (args[i].startsWith("--"))
         {
-            parent.options << args[i].mid(2);
+            parent.options << quoteArg(args[i].mid(2));
         }
         else
         {

--- a/src/gui/mpvadapter.h
+++ b/src/gui/mpvadapter.h
@@ -153,6 +153,13 @@ private:
                       int depth = 10) const;
 
     /**
+     * Quotes an option correctly
+     * @param arg argument to quote.
+     * @return the quoted argument if arg contained "=", otherwise arg.
+     */
+    QString quoteArg(QString arg) const;
+
+    /**
      * Loads files from a tree of LoadFileNodes.
      * @param parent  The parent to load files from.
      * @param options Options inherited by files at this level.


### PR DESCRIPTION
(sorry for the previous pr, this is the right one)

Currently, command line args don't work if they have escaped characters in them. This means that a command like

`memento video.mkv --sub-file="[abc] def.srt"`

doesn't work even though it's quoted to the user. This patch should fix this by inserting quotes around the value of the arg.