### PR TITLE
subtitlelistwidget: revamp how subtitle data from external file is handled

### DIFF
--- a/src/gui/mpvadapter.cpp
+++ b/src/gui/mpvadapter.cpp
@@ -338,6 +338,17 @@ int64_t MpvAdapter::getMaxVolume() const
     return max;
 }
 
+double MpvAdapter::getTimePos() const
+{
+    double timePos;
+    if (mpv_get_property(m_handle, "time-pos", MPV_FORMAT_DOUBLE, &timePos) < 0)
+    {
+        qDebug() << "Could not get time-pos property";
+        return 0;
+    }
+    return timePos;
+}
+
 double MpvAdapter::getSubStart() const
 {
     double start;

--- a/src/gui/mpvadapter.h
+++ b/src/gui/mpvadapter.h
@@ -40,6 +40,8 @@ public:
 
     int64_t getMaxVolume() const override;
 
+    double getTimePos() const override;
+
     double getSubStart() const override;
 
     double getSubEnd() const override;

--- a/src/gui/playeradapter.h
+++ b/src/gui/playeradapter.h
@@ -103,6 +103,12 @@ public:
      */
     virtual int64_t getMaxVolume() const = 0;
 
+   /**
+    * Get the current playback position
+    * @return The position in current file in seconds.
+    */
+    virtual double getTimePos() const = 0;
+
     /**
      * Get the start time of the current subtitle without delay.
      * @return The start time of the current subtitle in seconds.

--- a/src/gui/widgets/subtitlelistwidget.h
+++ b/src/gui/widgets/subtitlelistwidget.h
@@ -140,28 +140,32 @@ private Q_SLOTS:
     void handleSecondaryTrackChange(int64_t sid);
 
     /**
-     * Adds a subtitle to the primary subtitle list.
+     * Updates the current primary subtitle
+     * if the primary subtitles are not populated from
+     * an external track, add the current subtitle
      * @param subtitle The subtitle to add.
      * @param start    The start time of the subtitle.
      * @param end      The end time of the subtitle.
      * @param delay    The signed delay of the subtitle.
      */
-    void addPrimarySubtitle(const QString &subtitle,
-                            const double   start,
-                            const double   end,
-                            const double   delay);
+    void updatePrimarySubtitle(const QString &subtitle,
+                               const double   start,
+                               const double   end,
+                               const double   delay);
 
     /**
-     * Adds a subtitle to the secondary subtitle list.
+     * Updates the current secondary subtitle
+     * if the secondary subtitles are not populated from
+     * an external track, add the current subtitle
      * @param subtitle The subtitle to add.
      * @param start    The start time of the subtitle.
      * @param end      The end time of the subtitle.
      * @param delay    The signed delay of the subtitle.
      */
-    void addSecondarySubtitle(const QString &subtitle,
-                              const double   start,
-                              const double   end,
-                              const double   delay);
+    void updateSecondarySubtitle(const QString &subtitle,
+                                 const double   start,
+                                 const double   end,
+                                 const double   delay);
 
     /**
      * Updates the timestamps of the subtitles with a new delay.
@@ -340,6 +344,12 @@ private:
 
     /* Holds subtitle info for the current secondary track. */
     QList<SubtitleInfo> *m_secondarySubInfoList;
+
+    /* Flag for whether the primary subs have been parsed & populated */
+    bool m_didParsePrimarySubs = false;
+
+    /* Flag for whether the secondary subs have been parsed & populated */
+    bool m_didParseSecondarySubs = false;
 };
 
 #endif // SUBTITLELISTWIDGET_H


### PR DESCRIPTION
### Motivation
This PR is part of https://github.com/ripose-jp/Memento/issues/29. During testing, I found that a fair number of subs in the wild have sequential entries that overlap by milliseconds:
```
19
00:02:29,732 --> 00:02:31,250
（あおいのくしゃみ）

20
00:02:31,109 --> 00:02:33,361
（あおい）ちゅうか
むっちゃ寒いな
```
```
127
00:07:56,893 --> 00:08:01,220
調理や たき火など
座ったままでの作業がしやすく―

128
00:08:01,105 --> 00:08:03,240
ローチェアは座面が低く―

129
00:08:03,107 --> 00:08:06,486
ゆったり くつろぐことに
向いています
```
This creates the undesirable behavior where Memento's parser, emulating how mpv flattens overlapping subtitles, creates unwanted clutter. Additional, weird timing conditions can lead to the insertion of duplicate entries, even after Memento has finished parsing & populating.

While it is possible to sanitize the files, etc., I think it is better to leave them as they are. Meanwhile, as we already have full knowledge of subtitle information after parsing, I think the flattening / compressing behavior is in general undesirable. This PR first adds a settings option that allows the flattening to be turned off. Additionally, to eliminate duplicate entries from happening, `subtitlelistwidget` now strictly only looks up subtitles after having parsed them, using mpv's `time-pos` property whenever the subtitle changes. No change has been made to `subtitlewidget` which still uses `sub-text`.

More details in the commit message:
This commit eliminates additional reliance on mpv `sub-text` properties when updating the `subtitlelistwidget`, and offers a settings option to turn off flattening (compressing) simultaneous subtitle entries. `subtitlelistwidget` now maintains a flag to show whether it has parsed subtitles & populated the list. A new `getTimePos property` is added to `mpvadapter`. Now on subtitle change, if the flag has been set, `subtitlelistwidget` assumes that the newly appeared subtitle is already in the list, and looks it up with `timePos`. `addPrimary/SecondarySubtitle` have been refractored to `updatePrimary/SecondarySubtitle` for this purpose.