### PR TITLE
Enable high-dpi support on macOS

### DIFF
--- a/macos/MementoInfo.plist.in
+++ b/macos/MementoInfo.plist.in
@@ -28,6 +28,10 @@
 	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
 	<key>CSResourcesFileMapped</key>
 	<true/>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSHighResolutionCapable</key>
+	<string>True</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
 </dict>


### PR DESCRIPTION
This change enables high-dpi support on macOS systems, following guidelines from https://doc.qt.io/qt-5/highdpi.html#macos-and-ios.