### PR TITLE
glossarylabel: add default to switch statement

### DIFF
--- a/src/gui/widgets/definition/glossarylabel.cpp
+++ b/src/gui/widgets/definition/glossarylabel.cpp
@@ -425,6 +425,8 @@ void GlossaryLabel::addStructuredContent(
     case QJsonValue::Type::Object:
         addStructuredContentHelper(val.toObject(), basepath, out);
         break;
+    default:
+        break;
     }
 }
 


### PR DESCRIPTION
Add missing default to silence compiler warnings:

```
.../src/anki/glossarybuilder.cpp:392:13: warning: 4 enumeration values not handled in switch: 'Null', 'Bool', 'Double'... [-Wswitch]
    switch (val.type())
            ^
.../src/anki/glossarybuilder.cpp:392:13: note: add missing switch cases
    switch (val.type())
            ^
```

This makes it like the other `switch (val.type())` on line 98.