### PR TITLE
src/audio/audioplayer: do not use open() on QNetworkReply

### DIFF
--- a/src/audio/audioplayer.cpp
+++ b/src/audio/audioplayer.cpp
@@ -146,12 +146,6 @@ AudioPlayerReply *AudioPlayer::playAudio(QString url, QString hash)
                 goto cleanup;
             }
 
-            if (!reply->open(QIODevice::ReadOnly))
-            {
-                qDebug() << "Could not open audio reply";
-                goto cleanup;
-            }
-
             /* Put the audio in a new temp file */
             file = new QTemporaryFile;
             if (!file->open())


### PR DESCRIPTION
For some reason, calling `open()` on the network reply for an audio clip, clears out the buffer so you can no longer read data from it anymore, unless it is internally handled as a zero-copy buffer, which is not public.

During testing, trying to play an audio clip for a word from `assets.japanesepod101.com` results in an empty temp file being written. Calling `bytesAvailable()` before `open()` gives a valid number, but after the `open()` it becomes 0 and no data can be read.
However, trying to retrieve audio for non-existing words (With the voiced response "The audio for this clip is currently not available...") works fine and `bytesAvailable()` will show about 50KB even after `open()` is called.

After a lot of debugging, it turns out that in the latter case, the data is stored in the private `downloadZerocopyBuffer` of the `QNetworkReplyHttpImplPrivate` class, while it was stored in a "normal" buffer in the other cases, perhaps as an optimization further down the network stack that only happens with larger payloads (Most other audio clips seem to be only 2-5KB in size).

This honestly seems like a Qt bug to me, but I couldn't find any report and struggled to set up a minimal example to make one myself. I also couldn't find any example of people using `open()` on a `QNetworkReply` object. It looks like it's not something necessary to do, so removing it fixes the issue.

I tested this on Arch Linux with kernel 6.9.3-zen and Qt 6.7.1, but remember audio clips already being broken for some while before that.