### PR TITLE
src/player/mpvadapter: fix compatibility with mpv 0.38.0

### DIFF
--- a/src/player/mpvadapter.cpp
+++ b/src/player/mpvadapter.cpp
@@ -591,12 +591,18 @@ void MpvAdapter::open(const QString     &file,
 
     QByteArray filename = file.toUtf8();
     QByteArray opts = options.join(',').toUtf8();
+    char *argOpts = opts.isEmpty() ? NULL : opts.data();
 
-    const char *args[5] = {
+    /* Since mpv client API 2.3 (mpv 0.38.0) "loadfile" places an extra argument before the options,
+       so we need to conditionally re-arrange the arguments array */
+    bool isApi23 = mpv_client_api_version() >= MPV_MAKE_VERSION(2, 3);
+
+    const char *args[] = {
         "loadfile",
         filename,
         append ? "append-play" : "replace",
-        opts.isEmpty() ? NULL : opts.data(),
+        isApi23 ? "0"     : argOpts,
+        isApi23 ? argOpts : NULL,
         NULL
     };
 
@@ -918,11 +924,15 @@ QString MpvAdapter::tempAudioClip(
     optionCmd += QString("start=%1").arg(start, 0, 'f', 3).toUtf8();
     optionCmd += QString(",end=%1").arg(end, 0, 'f', 3).toUtf8();
     optionCmd += QString(",aid=%1").arg(aid).toUtf8();
+    char *argOpts = optionCmd.isEmpty() ? NULL : optionCmd.data();
+
+    bool isApi23 = mpv_client_api_version() >= MPV_MAKE_VERSION(2, 3);
     const char *args[] = {
         "loadfile",
         input,
         "replace",
-        optionCmd.isEmpty() ? NULL : optionCmd.data(),
+        isApi23 ? "0"     : argOpts,
+        isApi23 ? argOpts : NULL,
         NULL
     };
 


### PR DESCRIPTION
Since version 0.38.0, mpv requires an additional integer argument ("index") for the `loadfile` command that comes before the options, but is ignored in most cases ([see documentation](https://mpv.io/manual/master/#command-interface-[%3Coptions%3E]]])). I guess when you tried adjusting for mpv 0.38.0 before in https://github.com/ripose-jp/Memento/commit/02ce0bdfba2f3fe485ab6b33b85f8d9022f58e19, the error you mention probably is because it was expecting an integer argument for the position where the options used to be, and passing NULL removes the argument all together, but this should still break all cases where there actually are options that are passed to `loadfile`, including the very much important start and end times for `tempAudioClip()`, so I'm confused how this seems to have gone unnoticed.

Anyway, since the order of arguments now depends on the mpv version the user has installed on the system (at least when it is dynamically linked like on Linux), we need to implement a runtime version check that conditionally stuffs an argument before the options string. This value can be arbitrary since it is ignored in our cases.
Another potential option would be using `mpv_set_option_string()` to set the `start,end,aid` options (and maybe even the input file?) to avoid having to pass these arguments with `loadfile` all together, which worked with both mpv 0.37.0 and 0.38.0.

Here is the commit that brings the breaking change, the comments might be worth reading: https://github.com/mpv-player/mpv/commit/c678033c1d60b48ae02fbbe4815869b9504a17f6