### PR TITLE
ankisettings: add {tags-brief} marker

### DIFF
--- a/src/anki/ankiclient.h
+++ b/src/anki/ankiclient.h
@@ -48,6 +48,7 @@
 #define REPLACE_SENTENCE            "{sentence}"
 #define REPLACE_SENTENCE_SEC        "{sentence-2}"
 #define REPLACE_TAGS                "{tags}"
+#define REPLACE_TAGS_BRIEF          "{tags-brief}"
 #define REPLACE_TITLE               "{title}"
 
 /* Term Markers */
@@ -483,10 +484,13 @@ private:
     /**
      * Helper method for wrapping tags in <li></li>'s.
      * @param      tags   The tags to create a list from.
-     * @param[out] tagStr The string to append to.
-     * @return tagstr
+     * @param[out] tagStr The string to append to for the detailed tag list.
+     * @param[out] tagBriefStr The string to append to for a brief tag list.
      */
-    QString &accumulateTags(const QList<Tag> &tags, QString &tagStr);
+    void buildTags(
+        const QList<Tag> &tags,
+        QString &tagStr,
+        QString &tagBriefStr);
 
     /**
      * Helper method to convert file to base64.

--- a/src/gui/widgets/settings/ankisettings.cpp
+++ b/src/gui/widgets/settings/ankisettings.cpp
@@ -57,6 +57,7 @@ AnkiSettings::AnkiSettings(QWidget *parent)
             REPLACE_SENTENCE,
             REPLACE_SENTENCE_SEC,
             REPLACE_TAGS,
+            REPLACE_TAGS_BRIEF,
             REPLACE_TITLE,
 
             /* Term */

--- a/src/gui/widgets/settings/ankisettingshelp.ui
+++ b/src/gui/widgets/settings/ankisettingshelp.ui
@@ -69,7 +69,7 @@ These will expand to larger expressions in the final card.</string>
            </property>
           </widget>
          </item>
-         <item row="25" column="1">
+         <item row="26" column="1">
           <widget class="QLabel" name="labelTermTitleEx">
            <property name="text">
             <string>Title of the video. Filename if no title.</string>
@@ -594,7 +594,7 @@ These will expand to larger expressions in the final card.</string>
            </property>
           </widget>
          </item>
-         <item row="25" column="0">
+         <item row="26" column="0">
           <widget class="QLabel" name="labelTermTitle">
            <property name="font">
             <font>
@@ -685,6 +685,32 @@ These will expand to larger expressions in the final card.</string>
            </property>
            <property name="textInteractionFlags">
             <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+           </property>
+          </widget>
+         </item>
+         <item row="25" column="0">
+          <widget class="QLabel" name="labelTermTagsBrief">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>{tags-brief}</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+           </property>
+          </widget>
+         </item>
+         <item row="25" column="1">
+          <widget class="QLabel" name="labelTermTagsBriefEx">
+           <property name="text">
+            <string>Bulleted list of the term tags without description.</string>
            </property>
           </widget>
          </item>
@@ -969,6 +995,25 @@ These will expand to larger expressions in the final card.</string>
            </property>
           </widget>
          </item>
+         <item row="19" column="0">
+          <widget class="QLabel" name="labelKanjiTagsBrief">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>{tags-brief}</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+           </property>
+          </widget>
+         </item>
          <item row="9" column="1">
           <widget class="QLabel" name="labelKanjiFrequenciesEx">
            <property name="text">
@@ -1032,6 +1077,13 @@ These will expand to larger expressions in the final card.</string>
           <widget class="QLabel" name="labelKanjiTagsEx">
            <property name="text">
             <string>Bulleted list of the term tags.</string>
+           </property>
+          </widget>
+         </item>
+         <item row="19" column="1">
+          <widget class="QLabel" name="labelKanjiTagsBriefEx">
+           <property name="text">
+            <string>Bulleted list of the term tags without description.</string>
            </property>
           </widget>
          </item>
@@ -1135,7 +1187,7 @@ These will expand to larger expressions in the final card.</string>
            </property>
           </widget>
          </item>
-         <item row="19" column="0">
+         <item row="20" column="0">
           <widget class="QLabel" name="labelKanjiTitle">
            <property name="font">
             <font>
@@ -1249,7 +1301,7 @@ These will expand to larger expressions in the final card.</string>
            </property>
           </widget>
          </item>
-         <item row="19" column="1">
+         <item row="20" column="1">
           <widget class="QLabel" name="labelKanjiTitleEx">
            <property name="text">
             <string>Title of the video. Filename if no title.</string>


### PR DESCRIPTION
I was looking for a more compact version of tags, like they appear in the popup window, so I added `{tags-brief}`, which does the same as `{tags}` but doesn't include the tag descriptions. I was thinking about making it a one-line string instead, but keeping it as a list allows styling it either way using CSS. This way it also allows styling it as bubbles the same way it is in the popup.