### PR TITLE
databasemanager: support more frequency meta term bank formats

### DIFF
--- a/src/dict/databasemanager.cpp
+++ b/src/dict/databasemanager.cpp
@@ -757,21 +757,52 @@ int DatabaseManager::addFrequencies(
                 {
                     continue;
                 }
-                obj = obj[OBJ_FREQ_KEY].toObject();
             }
 
-            /* Check for the type that should be shown */
-            if (obj[OBJ_DISPLAY_KEY].isString())
+            /* First scenario:
+             * [
+             *     "<term>","freq",{"reading":"<reading>","frequency":<number>}
+             * ]
+             */
+            if (obj[OBJ_FREQ_KEY].isDouble())
             {
-                freqStr = obj[OBJ_DISPLAY_KEY].toString();
+                freqStr = QString::number(obj[OBJ_FREQ_KEY].toInt());
             }
-            else if (obj[OBJ_VALUE_KEY].isDouble())
+
+            /* Second scenario:
+             * [
+             *     "<term>","freq",{"reading":"<reading>","frequency": "<frequency string>">}
+             * ]
+             */
+            else if (obj[OBJ_FREQ_KEY].isString())
             {
-                freqStr = QString::number(obj[OBJ_VALUE_KEY].toInt());
+                freqStr = obj[OBJ_FREQ_KEY].toString();
             }
-            else
+
+            /* Third scenario:
+             * [
+             *     "<term>","freq",
+             *     {"reading":"<reading>",
+             *        "frequency": {"value": <number>, "displayValue": "<stylized frequency string>"}
+             *     }
+             * ]
+             */
+            else if (obj[OBJ_FREQ_KEY].isObject())
             {
-                continue;
+                obj = obj[OBJ_FREQ_KEY].toObject();
+                /* Check for the type that should be shown */
+                if (obj[OBJ_DISPLAY_KEY].isString())
+                {
+                    freqStr = obj[OBJ_DISPLAY_KEY].toString();
+                }
+                else if (obj[OBJ_VALUE_KEY].isDouble())
+                {
+                    freqStr = QString::number(obj[OBJ_VALUE_KEY].toInt());
+                }
+                else
+                {
+                    continue;
+                }
             }
             break;
         }


### PR DESCRIPTION
The database manager was assuming that the blobs related to the term frequency all exclusively follow this format:
```
[
    "<term>","freq",
    {"reading":"<reading>",
       "frequency": {"value": <number>, "displayValue": "<stylized frequency string>"}
    }
]
```
However, the [dictionary-term-meta-bank-v3-schema](https://github.com/FooSoft/yomichan/blob/2f13cf5d2ad33a627152457a3f120deb76739f60/ext/data/schemas/dictionary-term-meta-bank-v3-schema.json) allows for multiple possible types for the value of the `frequency` key.

This pull request adds support for all possible types of `frequency` so that the pop-up can show frequency information for the highlighted term.