### PR TITLE
src/gui/mainwindow.cpp: init pal variable with the standard palette (Fixes #244)

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -243,7 +243,7 @@ void MainWindow::initTheme()
     settings.beginGroup(Constants::Settings::Interface::GROUP);
 
     /* Set Palette */
-    QPalette pal;
+    QPalette pal{QApplication::style()->standardPalette()};
     Constants::Theme theme = static_cast<Constants::Theme>(settings.value(
             Constants::Settings::Interface::THEME,
             static_cast<int>(Constants::Settings::Interface::THEME_DEFAULT)


### PR DESCRIPTION
Fixes a bug where just clicking "Apply" in the Interface settings alternates the UI theme between System and the selected theme on some platforms because the QPalette variable `pal` does not get properly populated.

Closes #244