### PR TITLE
src/anki/ankiclient: add {pitch-categories} marker

### DIFF
--- a/src/anki/ankiclient.h
+++ b/src/anki/ankiclient.h
@@ -63,6 +63,7 @@
 #define REPLACE_GLOSSARY_BRIEF      "{glossary-brief}"
 #define REPLACE_GLOSSARY_COMPACT    "{glossary-compact}"
 #define REPLACE_PITCH               "{pitch}"
+#define REPLACE_PITCH_CATEGORIES    "{pitch-categories}"
 #define REPLACE_PITCH_GRAPHS        "{pitch-graph}"
 #define REPLACE_PITCH_POSITIONS     "{pitch-position}"
 #define REPLACE_READING             "{reading}"
@@ -477,17 +478,23 @@ private:
     int getFrequencyAverage(const QList<Frequency> &freq);
 
     /**
-     * Creates the HTML representation of the pitch, pitch graph, and pitch
-     * position for the given pitches.
-     * @param pitches            The pitches to turn into HTML.
-     * @param[out] pitch         The HTML representation of the {pitch} marker.
-     * @param[out] pitchGraph    The HTML representation of the {pitch-graph}
-     *                           marker.
-     * @param[out] pitchPosition The HTML representation of the {pitch-position}
-     *                           marker.
+     * Creates the HTML representation of the pitch, pitch category, pitch graph,
+     * and pitch position for the given pitches.
+     * @param pitches              The pitches to turn into HTML.
+     * @param canBeKifuku          Is the term an i-adjective or a verb whose
+     *                             pitch accent is either kifuku or heiban.
+     * @param[out] pitch           The HTML representation of the {pitch} marker.
+     * @param[out] pitchCategories The comma-separated representation of the
+     *                             {pitch-categories} marker.
+     * @param[out] pitchGraph      The HTML representation of the {pitch-graph}
+     *                             marker.
+     * @param[out] pitchPosition   The HTML representation of the {pitch-position}
+     *                             marker.
      */
     void buildPitchInfo(const QList<Pitch> &pitches,
+                        const bool          canBeKifuku,
                         QString            &pitch,
+                        QString            &pitchCategories,
                         QString            &pitchGraph,
                         QString            &pitchPosition);
 
@@ -529,6 +536,12 @@ private:
      * @return The base64 encoded file.
      */
     static QString fileToBase64(const QString &path);
+
+    /**
+     * Helper method to determine if the kifuku pitch accent pattern
+     * is potentially applicable to a term, by checking its part-of-speech.
+     */
+    bool isKifukuApplicable(const QList<TermDefinition> &defs);
 
     /* true if a config exists, false otherwise */
     bool m_configExists = false;

--- a/src/gui/widgets/settings/ankisettings.cpp
+++ b/src/gui/widgets/settings/ankisettings.cpp
@@ -72,6 +72,7 @@ AnkiSettings::AnkiSettings(QWidget *parent)
             REPLACE_GLOSSARY_BRIEF,
             REPLACE_GLOSSARY_COMPACT,
             REPLACE_PITCH,
+            REPLACE_PITCH_CATEGORIES,
             REPLACE_PITCH_GRAPHS,
             REPLACE_PITCH_POSITIONS,
             REPLACE_READING,

--- a/src/gui/widgets/settings/ankisettingshelp.ui
+++ b/src/gui/widgets/settings/ankisettingshelp.ui
@@ -62,14 +62,14 @@ These will expand to larger expressions in the final card.</string>
            </property>
           </widget>
          </item>
-         <item row="24" column="1">
+         <item row="25" column="1">
           <widget class="QLabel" name="labelTermScreenshotEx">
            <property name="text">
             <string>Screenshot of the current frame.</string>
            </property>
           </widget>
          </item>
-         <item row="30" column="1">
+         <item row="31" column="1">
           <widget class="QLabel" name="labelTermTitleEx">
            <property name="text">
             <string>Title of the video. Filename if no title.</string>
@@ -95,14 +95,7 @@ These will expand to larger expressions in the final card.</string>
            </property>
           </widget>
          </item>
-         <item row="21" column="1">
-          <widget class="QLabel" name="labelTermPitchGraphEx">
-           <property name="text">
-            <string>Pitch graphs for the reading of the term.</string>
-           </property>
-          </widget>
-         </item>
-         <item row="23" column="0">
+         <item row="24" column="0">
           <widget class="QLabel" name="labelTermReading">
            <property name="font">
             <font>
@@ -128,7 +121,7 @@ These will expand to larger expressions in the final card.</string>
            </property>
           </widget>
          </item>
-         <item row="26" column="0">
+         <item row="27" column="0">
           <widget class="QLabel" name="labelTermSentence">
            <property name="font">
             <font>
@@ -154,7 +147,7 @@ These will expand to larger expressions in the final card.</string>
            </property>
           </widget>
          </item>
-         <item row="23" column="1">
+         <item row="24" column="1">
           <widget class="QLabel" name="labelTermReadingEx">
            <property name="text">
             <string>The reading of the word in kana.</string>
@@ -202,7 +195,7 @@ These will expand to larger expressions in the final card.</string>
            </property>
           </widget>
          </item>
-         <item row="25" column="1">
+         <item row="26" column="1">
           <widget class="QLabel" name="labelTermScreenshotVideo">
            <property name="text">
             <string>Screenshot of the current frame without subtitles if visible.</string>
@@ -228,7 +221,7 @@ These will expand to larger expressions in the final card.</string>
            </property>
           </widget>
          </item>
-         <item row="27" column="1">
+         <item row="28" column="1">
           <widget class="QLabel" name="labelTermSentence2Ex">
            <property name="text">
             <string>The current secondary subtitle.</string>
@@ -252,6 +245,63 @@ These will expand to larger expressions in the final card.</string>
            </property>
            <property name="text">
             <string>{pitch}</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+           </property>
+          </widget>
+         </item>
+         <item row="21" column="0">
+          <widget class="QLabel" name="labelTermPitchCategories">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>{pitch-categories}</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+           </property>
+          </widget>
+         </item>
+         <item row="22" column="0">
+          <widget class="QLabel" name="labelTermPitchGraph">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>{pitch-graph}</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+           </property>
+          </widget>
+         </item>
+         <item row="23" column="0">
+          <widget class="QLabel" name="labelTermPitchPosition">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>{pitch-position}</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignCenter</set>
@@ -322,14 +372,7 @@ These will expand to larger expressions in the final card.</string>
            </property>
           </widget>
          </item>
-         <item row="22" column="1">
-          <widget class="QLabel" name="labelTermPitchPositionEx">
-           <property name="text">
-            <string>Pitch positions for the reading of the term.</string>
-           </property>
-          </widget>
-         </item>
-         <item row="27" column="0">
+         <item row="28" column="0">
           <widget class="QLabel" name="labelTermSentence2">
            <property name="font">
             <font>
@@ -420,25 +463,6 @@ These will expand to larger expressions in the final card.</string>
            </property>
           </widget>
          </item>
-         <item row="21" column="0">
-          <widget class="QLabel" name="labelTermPitchGraph">
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>{pitch-graph}</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="textInteractionFlags">
-            <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-           </property>
-          </widget>
-         </item>
          <item row="18" column="0">
           <widget class="QLabel" name="labelTermGlossaryBrief">
            <property name="font">
@@ -458,7 +482,7 @@ These will expand to larger expressions in the final card.</string>
            </property>
           </widget>
          </item>
-         <item row="28" column="1">
+         <item row="29" column="1">
           <widget class="QLabel" name="labelTermTagsEx">
            <property name="text">
             <string>Bulleted list of the term tags.</string>
@@ -640,26 +664,7 @@ These will expand to larger expressions in the final card.</string>
            </property>
           </widget>
          </item>
-         <item row="22" column="0">
-          <widget class="QLabel" name="labelTermPitchPosition">
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>{pitch-position}</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="textInteractionFlags">
-            <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-           </property>
-          </widget>
-         </item>
-         <item row="25" column="0">
+         <item row="26" column="0">
           <widget class="QLabel" name="labelTermScreenshotMedia">
            <property name="font">
             <font>
@@ -698,7 +703,7 @@ These will expand to larger expressions in the final card.</string>
            </property>
           </widget>
          </item>
-         <item row="30" column="0">
+         <item row="31" column="0">
           <widget class="QLabel" name="labelTermTitle">
            <property name="font">
             <font>
@@ -724,7 +729,28 @@ These will expand to larger expressions in the final card.</string>
            </property>
           </widget>
          </item>
-         <item row="26" column="1">
+         <item row="21" column="1">
+          <widget class="QLabel" name="labelTermPitchCategoriesEx">
+           <property name="text">
+            <string>Comma-separated list of pitch accent categories for the term: heiban, kifuku, atamadaka, nakadaka, odaka</string>
+           </property>
+          </widget>
+         </item>
+         <item row="22" column="1">
+          <widget class="QLabel" name="labelTermPitchGraphEx">
+           <property name="text">
+            <string>Pitch graphs for the reading of the term.</string>
+           </property>
+          </widget>
+         </item>
+         <item row="23" column="1">
+          <widget class="QLabel" name="labelTermPitchPositionEx">
+           <property name="text">
+            <string>Pitch positions for the reading of the term.</string>
+           </property>
+          </widget>
+         </item>
+         <item row="27" column="1">
           <widget class="QLabel" name="labelTermSentenceEx">
            <property name="text">
             <string>The current subtitle.</string>
@@ -773,7 +799,7 @@ These will expand to larger expressions in the final card.</string>
            </property>
           </widget>
          </item>
-         <item row="28" column="0">
+         <item row="29" column="0">
           <widget class="QLabel" name="labelTermTags">
            <property name="font">
             <font>
@@ -792,7 +818,7 @@ These will expand to larger expressions in the final card.</string>
            </property>
           </widget>
          </item>
-         <item row="29" column="0">
+         <item row="30" column="0">
           <widget class="QLabel" name="labelTermTagsBrief">
            <property name="font">
             <font>
@@ -811,14 +837,14 @@ These will expand to larger expressions in the final card.</string>
            </property>
           </widget>
          </item>
-         <item row="29" column="1">
+         <item row="30" column="1">
           <widget class="QLabel" name="labelTermTagsBriefEx">
            <property name="text">
             <string>Bulleted list of the term tags without description.</string>
            </property>
           </widget>
          </item>
-         <item row="24" column="0">
+         <item row="25" column="0">
           <widget class="QLabel" name="labelTermScreenshot">
            <property name="font">
             <font>


### PR DESCRIPTION
Add a new Anki marker called {pitch-categories}. This marker is a comma-separated list of all the distinct pitch accent categories applicable to the term. For example, the {pitch-categories} of 赤い would be `kifuku,heiban` (or `heiban,kifuku` — no guarantees can be given in regards to the order).

All the available pitch accent categories are:

1. heiban (pitch position = 0)
2. atamadaka (pitch position = 1)
3. nakadaka (1 < pitch position < term.moras.size)
4. kifuku (1 <= pitch position < term.moras.size ; only applicable to i-adjectives and non-suru verbs)
5. odaka (pitch position = term.moras.size)

The corresponding marker in Yomitan is actually called {pitch-accent-categories} but given that Memento omits the `-accent-` part in its versions of all the other pitch accent markers, I stuck to Memento's naming style.

Partially solves #250.  