### PR TITLE
src/anki/ankiclient: add dictionary name when building glossary

### DIFF
--- a/src/anki/ankiclient.cpp
+++ b/src/anki/ankiclient.cpp
@@ -1959,8 +1959,8 @@ QList<QPair<QString, QString>> AnkiClient::buildGlossary(
 
     for (const TermDefinition &def : definitions)
     {
-        glossary += "<li>";
-        glossaryCompact += "<li>";
+        glossary += "<li data-dictionary=\"" + def.dictionary + "\">";
+        glossaryCompact += "<li data-dictionary=\"" + def.dictionary + "\">";
 
         glossary += "<i>(";
         glossaryCompact += "<i>(";


### PR DESCRIPTION
Adds the dictionary name to the first <li> HTML tag of each glossary by using the following format:
<li data-dictionary: {dictionary-name}>
during the glossary builder phase

After the implementation of #250 I tried using [lapis cards](https://github.com/donkuri/lapis) 
But it still haven't worked perfectly, and they were 99% compatible with memento for some odd reason


After digging into the lapis card code, I noticed that to create the scrollable definition box in the card
it relies on counting the number of definitions using the following JS code:
```javascript
// multiple dicts
const primaryDicts = document.querySelectorAll("#primary li[data-dictionary]");
const glossariesDicts = document.querySelectorAll("#glossaries li[data-dictionary]");
return primaryDicts.length === glossariesDicts.length
```

Digging more, I discovered there's a discrepancy between how memento builds the HTML for anki and how yomitan does it

Memento HTML:
https://pastebin.com/9j2xgMJx

Yomitan HTML:
https://pastebin.com/i6N9zzpY


This PR fixes this issue by adding that ``data-dictionary`` information in memento as well and fixing the issue with lapis cards.
