### PR TITLE
Allow setting `OSC_MIN_MOVE` to values greater than 99 via the UI

### DIFF
--- a/src/gui/widgets/settings/behaviorsettings.ui
+++ b/src/gui/widgets/settings/behaviorsettings.ui
@@ -216,6 +216,9 @@ The fade in duration is included in this time.</string>
               <property name="toolTip">
                <string>The number of pixels that need to be moved before the OSC is shown</string>
               </property>
+              <property name="maximum">
+               <number>10000</number>
+              </property>
              </widget>
             </item>
             <item>


### PR DESCRIPTION
Currently `OSC_MIN_MOVE` is limited to 99 via the UI, which makes the OSC appear every time the mouse is moved to scan subtitles.

The config file already supports higher values, this is purely a UI limitation.