### PR TITLE
Allow scan using middle mouse

### DIFF
--- a/src/gui/widgets/definition/definitionstate.h
+++ b/src/gui/widgets/definition/definitionstate.h
@@ -69,6 +69,9 @@ struct DefinitionState
 
     /* The modifier key used for executing sub-searches */
     Qt::KeyboardModifier searchModifier;
+
+    /* The flag for tiggering middle mouse scan */
+    bool middleMouseScan;
 };
 
 #endif // DEFINITIONSTATE_H

--- a/src/gui/widgets/definition/definitionwidget.cpp
+++ b/src/gui/widgets/definition/definitionwidget.cpp
@@ -171,6 +171,10 @@ void DefinitionWidget::initSearch()
     {
         m_state.searchModifier = Qt::KeyboardModifier::ShiftModifier;
     }
+    m_state.middleMouseScan = settings.value(
+        Constants::Settings::Search::MIDDLE_MOUSE_SCAN,
+        Constants::Settings::Search::MIDDLE_MOUSE_SCAN_DEFAULT
+    ).toBool();
     settings.endGroup();
 }
 

--- a/src/gui/widgets/definition/glossarylabel.h
+++ b/src/gui/widgets/definition/glossarylabel.h
@@ -34,12 +34,14 @@ class GlossaryLabel : public QTextEdit
 public:
     /**
      * Creates a new glossary label.
-     * @param modifier The modifier that triggers recursive searches.
-     * @param style    The style to display different definitions in.
-     * @param parent   The parent of this label.
+     * @param modifier        The modifier that triggers recursive searches.
+     * @param middleMouseScan The flag for triggering middle mouse scan.
+     * @param style           The style to display different definitions in.
+     * @param parent          The parent of this label.
      */
     GlossaryLabel(
         Qt::KeyboardModifier modifier = Qt::KeyboardModifier::ShiftModifier,
+        bool middleMouseScan = false,
         Constants::GlossaryStyle style = Constants::GlossaryStyle::Bullet,
         QWidget *parent = nullptr);
     virtual ~GlossaryLabel();
@@ -199,11 +201,21 @@ private:
     [[nodiscard]]
     static bool containsStructuredContent(const QJsonArray &definitions);
 
+    /**
+     * Helper method to initiate the finding terms in search or glossary.
+     * @param position Location of the cursor in the text.
+     */
+    void findTerms(int position);
+
     /* The modifier that triggers searches */
     Qt::KeyboardModifier m_searchModifier = Qt::KeyboardModifier::ShiftModifier;
 
+    /* Determines if to scan content using middle mouse button*/
+    bool m_middleMouseScan = false;
+
     /* The style of this label */
-    Constants::GlossaryStyle m_style;
+    Constants::GlossaryStyle m_style =
+        Constants::Settings::Search::LIST_GLOSSARY_DEFAULT;
 
     /* The index that is currently being searched */
     int m_currentIndex = -1;

--- a/src/gui/widgets/definition/glossarywidget.cpp
+++ b/src/gui/widgets/definition/glossarywidget.cpp
@@ -27,10 +27,11 @@
 #include "util/utils.h"
 
 GlossaryWidget::GlossaryWidget(
-    const size_t number,
+    size_t number,
     const TermDefinition &def,
-    const Qt::KeyboardModifier modifier,
-    const Constants::GlossaryStyle style,
+    Qt::KeyboardModifier modifier,
+    bool middleMouseScan,
+    Constants::GlossaryStyle style,
     QWidget *parent)
     : QWidget(parent),
       m_def(def)
@@ -39,7 +40,7 @@ GlossaryWidget::GlossaryWidget(
     m_layoutHeader  = new FlowLayout(-1, 6);
     m_checkBoxAdd   = new QCheckBox;
     m_labelNumber   = new QLabel;
-    m_glossaryLabel = new GlossaryLabel(modifier, style);
+    m_glossaryLabel = new GlossaryLabel(modifier, middleMouseScan, style);
 
     m_parentLayout->setContentsMargins(0, 0, 0, 0);
     m_parentLayout->addLayout(m_layoutHeader);

--- a/src/gui/widgets/definition/glossarywidget.h
+++ b/src/gui/widgets/definition/glossarywidget.h
@@ -41,16 +41,18 @@ class GlossaryWidget : public QWidget
 public:
     /**
      * Constructor for the GlossaryWidget.
-     * @param number   The number to label the term.
-     * @param def      The term definition to display.
-     * @param modifier The modifier key for triggering searches.
-     * @param style    The style of the GlossaryLabel.
-     * @param parent   The parent of the GlossaryWidget.
+     * @param number          The number to label the term.
+     * @param def             The term definition to display.
+     * @param modifier        The modifier key for triggering searches.
+     * @param middleMouseScan The flag for triggering middle mouse scan.
+     * @param style           The style of the GlossaryLabel.
+     * @param parent          The parent of the GlossaryWidget.
      */
     GlossaryWidget(
         size_t number,
         const TermDefinition &def,
         Qt::KeyboardModifier modifier,
+        bool middleMouseScan,
         Constants::GlossaryStyle style,
         QWidget *parent = nullptr);
 

--- a/src/gui/widgets/definition/termwidget.cpp
+++ b/src/gui/widgets/definition/termwidget.cpp
@@ -136,7 +136,12 @@ TermWidget::TermWidget(
     m_ui->buttonAudio->setIcon(factory->getIcon(IconFactory::Icon::audio));
     m_ui->buttonAudio->setVisible(!m_sources.empty());
 
-    initUi(*term, m_state.searchModifier, m_state.glossaryStyle);
+    initUi(
+        *term,
+        m_state.searchModifier,
+        m_state.middleMouseScan,
+        m_state.glossaryStyle
+    );
 
     connect(
         m_ui->buttonCollapse, &QToolButton::clicked,
@@ -201,6 +206,7 @@ void TermWidget::deleteWhenReady()
 void TermWidget::initUi(
     const Term &term,
     Qt::KeyboardModifier modifier,
+    bool middleMouseScan,
     Constants::GlossaryStyle style)
 {
     if (term.reading.isEmpty())
@@ -262,7 +268,7 @@ void TermWidget::initUi(
     for (int i = 0; i < term.definitions.size(); ++i)
     {
         GlossaryWidget *g = new GlossaryWidget(
-            i + 1, term.definitions[i], modifier, style
+            i + 1, term.definitions[i], modifier, middleMouseScan, style
         );
         g->setChecked(
             !config->excludeGloss.contains(term.definitions[i].dictionary)

--- a/src/gui/widgets/definition/termwidget.h
+++ b/src/gui/widgets/definition/termwidget.h
@@ -54,9 +54,9 @@ class TermWidget : public QWidget
 public:
     /**
      * Constructor for TermWidget.
-     * @param term        The term to display. Does not take ownership.
-     * @param state       The state of the parent of this widget.
-     * @param parent      The parent of this widget.
+     * @param term   The term to display. Does not take ownership.
+     * @param state  The state of the parent of this widget.
+     * @param parent The parent of this widget.
      */
     TermWidget(
         std::shared_ptr<const Term> term,
@@ -167,13 +167,15 @@ private Q_SLOTS:
 private:
     /**
      * Puts term information into the UI.
-     * @param term     The term to populate the UI with.
-     * @param modifier The modifier key for triggering recursive search.
-     * @param style    The style of the GlossaryWidget.
+     * @param term            The term to populate the UI with.
+     * @param modifier        The modifier key for triggering recursive search.
+     * @param middleMouseScan The flag for triggering middle mouse scan.
+     * @param style           The style of the GlossaryWidget.
      */
     void initUi(
         const Term &term,
         Qt::KeyboardModifier modifier,
+        bool middleMouseScan,
         Constants::GlossaryStyle style);
 
     /**

--- a/src/gui/widgets/overlay/subtitlewidget.cpp
+++ b/src/gui/widgets/overlay/subtitlewidget.cpp
@@ -297,7 +297,10 @@ void SubtitleWidget::initSettings()
     {
         m_settings.method = Settings::SearchMethod::Hover;
     }
-
+    m_settings.middleMouseScan = settings.value(
+            Constants::Settings::Search::MIDDLE_MOUSE_SCAN,
+            Constants::Settings::Search::MIDDLE_MOUSE_SCAN_DEFAULT
+        ).toBool();
     m_settings.hideSubsWhenVisible = settings.value(
             Constants::Settings::Search::HIDE_SUBS,
             Constants::Settings::Search::HIDE_SUBS_DEFAULT
@@ -388,6 +391,27 @@ void SubtitleWidget::mouseMoveEvent(QMouseEvent *event)
             findTerms();
         }
         break;
+    }
+
+    event->ignore();
+}
+
+void SubtitleWidget::mousePressEvent(QMouseEvent *event)
+{
+    StrokeLabel::mousePressEvent(event);
+
+    int position = getPosition(event->pos());
+    if (!m_paused || position == m_currentIndex || position == -1)
+    {
+        return;
+    }
+
+    if(m_settings.method == Settings::SearchMethod::Modifier &&
+        m_settings.middleMouseScan &&
+        event->button() == Qt::MiddleButton)
+    {
+        m_currentIndex = position;
+        findTerms();
     }
 
     event->ignore();

--- a/src/gui/widgets/overlay/subtitlewidget.h
+++ b/src/gui/widgets/overlay/subtitlewidget.h
@@ -49,6 +49,14 @@ protected:
     void mouseMoveEvent(QMouseEvent *event) override;
 
     /**
+     * Used for starting searches.
+     * If m_settings.middleMouseScan is true and m_settings.method is Modifier
+     * starts a direct search.
+     * @param event The mouse move event.
+     */
+    void mousePressEvent(QMouseEvent *event) override;
+
+    /**
      * Copys the current subtitle to clipboard.
      * @param event Mouse event, not used.
      */
@@ -181,6 +189,9 @@ private:
 
         /* The currently set search method. */
         SearchMethod method;
+
+        /* Whether search is set to trigger on middle mouse press*/
+        bool middleMouseScan;
 
         /* The hover delay, before a search is triggered. */
         int delay;

--- a/src/gui/widgets/searchwidget.h
+++ b/src/gui/widgets/searchwidget.h
@@ -48,11 +48,15 @@ class SearchEdit : public QLineEdit
 public:
     /**
      * Constructs a SearchEdit.
-     * @param modifier The modifier this SearchEdit uses to trigger searches.
-     * @param parent   The parent of this SearchEdit.
+     * @param modifier              The modifier this SearchEdit uses to trigger
+     *                              searches.
+     * @param searchWithMiddleMouse True to search with middle mouse, false
+     *                              otherwise.
+     * @param parent                The parent of this SearchEdit.
      */
     SearchEdit(
         Qt::KeyboardModifier modifier = Qt::KeyboardModifier::ShiftModifier,
+        bool searchWithMiddleMouse = false,
         QWidget *parent = nullptr);
 
     /**
@@ -60,6 +64,12 @@ public:
      * @param modifier The modifier to use.
      */
     void setModifier(Qt::KeyboardModifier modifier);
+
+    /**
+     * Sets if searches should be triggered by middle mouse.
+     * @param enabled true to enable, false to disable.
+     */
+    void setSearchWithMiddleMouse(bool enabled);
 
 Q_SIGNALS:
     /**
@@ -76,9 +86,18 @@ protected:
      */
     void mouseMoveEvent(QMouseEvent *event) override;
 
+    /**
+     * Handle the triggering of searches with middle mouse.
+     * @param event The mouse move event.
+     */
+    void mousePressEvent(QMouseEvent *event) override;
+
 private:
     /* The modifier used to trigger searches */
-    Qt::KeyboardModifier m_modifier;
+    Qt::KeyboardModifier m_modifier = Qt::KeyboardModifier::ShiftModifier;
+
+    /* True if middle mouse should be used for searches, false otherwise */
+    bool m_searchWithMiddleMouse = false;
 
     /* The last index that caused searchTriggered to fire */
     int m_lastIndex = -1;

--- a/src/gui/widgets/settings/searchsettings.cpp
+++ b/src/gui/widgets/settings/searchsettings.cpp
@@ -145,6 +145,12 @@ void SearchSettings::restoreSaved()
             Constants::Settings::Search::DELAY_DEFAULT
         ).toInt()
     );
+    m_ui->checkMiddleMouse->setChecked(
+        settings.value(
+            Constants::Settings::Search::MIDDLE_MOUSE_SCAN,
+            Constants::Settings::Search::MIDDLE_MOUSE_SCAN_DEFAULT
+        ).toBool()
+    );
     m_ui->comboBoxModifier->setCurrentText(
         settings.value(
             Constants::Settings::Search::MODIFIER,
@@ -227,6 +233,9 @@ void SearchSettings::restoreDefaults()
     m_ui->comboBoxModifier->setCurrentText(
         Constants::Settings::Search::MODIFIER_DEFAULT
     );
+    m_ui->checkMiddleMouse->setChecked(
+        Constants::Settings::Search::MIDDLE_MOUSE_SCAN_DEFAULT
+    );
     m_ui->checkHideSubs->setChecked(
         Constants::Settings::Search::HIDE_SUBS_DEFAULT
     );
@@ -288,6 +297,10 @@ void SearchSettings::applySettings()
     settings.setValue(
         Constants::Settings::Search::MODIFIER,
         m_ui->comboBoxModifier->currentText()
+    );
+    settings.setValue(
+        Constants::Settings::Search::MIDDLE_MOUSE_SCAN,
+        m_ui->checkMiddleMouse->isChecked()
     );
     settings.setValue(
         Constants::Settings::Search::HIDE_SUBS,

--- a/src/gui/widgets/settings/searchsettings.ui
+++ b/src/gui/widgets/settings/searchsettings.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QScrollArea" name="scrollArea">
      <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
+      <enum>QFrame::Shape::NoFrame</enum>
      </property>
      <property name="widgetResizable">
       <bool>true</bool>
@@ -27,8 +27,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>756</width>
-        <height>683</height>
+        <width>750</width>
+        <height>689</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="layoutScrollArea">
@@ -48,7 +48,6 @@
         <widget class="QLabel" name="labelMatcher">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -92,7 +91,6 @@ Includes deconjugation information in results.</string>
         <widget class="QLabel" name="labelLimit">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -117,7 +115,6 @@ Zero is equivalent to no limit.</string>
         <widget class="QLabel" name="labelMethod">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -138,10 +135,10 @@ Zero is equivalent to no limit.</string>
        <item>
         <widget class="QFrame" name="frameHover">
          <property name="frameShape">
-          <enum>QFrame::StyledPanel</enum>
+          <enum>QFrame::Shape::StyledPanel</enum>
          </property>
          <property name="frameShadow">
-          <enum>QFrame::Raised</enum>
+          <enum>QFrame::Shadow::Raised</enum>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout">
           <item>
@@ -154,7 +151,6 @@ Zero is equivalent to no limit.</string>
             </property>
             <property name="font">
              <font>
-              <weight>75</weight>
               <bold>true</bold>
              </font>
             </property>
@@ -194,7 +190,6 @@ Changing this value from the default is not recommended.</string>
         <widget class="QLabel" name="labelModifier">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -212,6 +207,13 @@ Changing this value from the default is not recommended.</string>
        </item>
        <item>
         <layout class="QVBoxLayout" name="layoutCheckHide">
+         <item>
+          <widget class="QCheckBox" name="checkMiddleMouse">
+           <property name="text">
+            <string>Search using middle mouse button</string>
+           </property>
+          </widget>
+         </item>
          <item>
           <widget class="QCheckBox" name="checkHideSubs">
            <property name="text">
@@ -308,7 +310,6 @@ Changing this value from the default is not recommended.</string>
         <widget class="QLabel" name="labelRemoveRegex">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -329,7 +330,7 @@ Changes to the primary subtitle will appear in the subtitle list, Anki cards, an
        <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -346,7 +347,7 @@ Changes to the primary subtitle will appear in the subtitle list, Anki cards, an
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Apply|QDialogButtonBox::Reset|QDialogButtonBox::RestoreDefaults</set>
+      <set>QDialogButtonBox::StandardButton::Apply|QDialogButtonBox::StandardButton::Reset|QDialogButtonBox::StandardButton::RestoreDefaults</set>
      </property>
     </widget>
    </item>

--- a/src/util/constants.h
+++ b/src/util/constants.h
@@ -182,6 +182,9 @@ namespace Constants
                 constexpr const char *SUPER = "Super";
             }
 
+            constexpr const char *MIDDLE_MOUSE_SCAN = "middle-mouse-scan";
+            constexpr bool MIDDLE_MOUSE_SCAN_DEFAULT = false;
+
             constexpr const char *LIMIT = "limit";
             constexpr int LIMIT_DEFAULT = 10;
 


### PR DESCRIPTION
Closes #128 

This feature adds the option to scan terms using middle mouse button.

A new option in the setting page was added to handle middle mouse scan. Since this feature only makes sense when search method is not hover, the new checkbox and the modifier settings are now bundled under a layout, and the layout will be visible only when search method is equal to modifier (similar to scan delay being only visible when search method is hover).

The new search setting page:

Hover:
![image](https://github.com/user-attachments/assets/deeb0607-2668-4cea-9b21-90b4e08ffd47)


Modifier:
![image](https://github.com/user-attachments/assets/decfb0ce-2fe1-4212-9587-273f81fc87cd)

