### PR TITLE
src/anki/notebuilder: allow filtering only lowest frequency

### DIFF
--- a/src/gui/widgets/settings/ankisettingshelp.ui
+++ b/src/gui/widgets/settings/ankisettingshelp.ui
@@ -1725,6 +1725,50 @@ These will expand to larger expressions in the final card.</string>
              </property>
             </widget>
            </item>
+           <item row="6" column="0" alignment="Qt::AlignmentFlag::AlignHCenter">
+            <widget class="QLabel" name="labelExtendedFrequencyMinValue">
+             <property name="font">
+              <font>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>min-value</string>
+             </property>
+             <property name="textInteractionFlags">
+              <set>Qt::TextInteractionFlag::TextSelectableByKeyboard|Qt::TextInteractionFlag::TextSelectableByMouse</set>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="1">
+            <widget class="QLabel" name="labelExtendedFrequencyMinValueEx">
+             <property name="text">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Only export the lowest value frequency. Applies to marker &lt;span style=&quot; font-weight:700;&quot;&gt;{frequencies}&lt;/span&gt;. Default value: false.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="0" alignment="Qt::AlignmentFlag::AlignHCenter">
+            <widget class="QLabel" name="labelExtendedFrequencyValueOnly">
+             <property name="font">
+              <font>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>value-only</string>
+             </property>
+             <property name="textInteractionFlags">
+              <set>Qt::TextInteractionFlag::TextSelectableByKeyboard|Qt::TextInteractionFlag::TextSelectableByMouse</set>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="1">
+            <widget class="QLabel" name="labelExtendedFrequencyValueOnlyEx">
+             <property name="text">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Export frequency values without the dictionary names. Applies to marker &lt;span style=&quot; font-weight:700;&quot;&gt;{frequencies}&lt;/span&gt;. Default value: false.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+            </widget>
+           </item>
           </layout>
          </widget>
         </widget>


### PR DESCRIPTION
Closes #202 

This feature extends the ``{frequencies}`` marker with the extended marker syntax and adds two new options: ``min-value`` which allows to export only the lowest value frequency out of all the options and ``value-only`` which strips the dictionary name and html list format to keep only raw numbers.

This allow memento to support card format that rely on raw frequency values to sort their cards.

Example of results:
``{frequencies}`` or ``{frequencies:min-value=false,value-only=false}``
![image](https://github.com/user-attachments/assets/a2f408ed-9115-4c56-b017-371ac5c527a3)


 ``{frequencies:min-value=true,value-only=false}``
![image](https://github.com/user-attachments/assets/522391bc-6804-42d2-82cf-19ddfa716856)


``{frequencies:min-value=false,value-only=true}`` (note: values are separated by ``\n``)
![image](https://github.com/user-attachments/assets/504f4969-f9ac-433d-9cdb-f9d41b897d9c)


``{frequencies:min-value=true,value-only=true}``
![image](https://github.com/user-attachments/assets/d71f661f-c1f2-4de7-adf2-2d8a3dfa201e)


Edit: I would add that this essentially serves the same end result of ``{frequency-harmonic-rank}`` and ``frequency-average-rank``, to sort anki cards base on frequency values, but by having different values. So this might not bring any novel/unique features to memento but allow for users to have more variety on some of the values/fields 